### PR TITLE
feat: async commands

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,6 +4,7 @@ import "./App.css";
 
 function App() {
 	const [showTerminal, setShowTerminal] = useState(true);
+
 	const commands = {
 		bat: (args: string) => {
 			if (args === "sum.js")
@@ -23,8 +24,9 @@ function App() {
 				<div>hii</div>
 			</>
 		),
-		"foo bar": () => {
-			window.alert("hellooooo");
+		"foo bar": async () => {
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			return "Resolved after 3 seconds!";
 		},
 		thisIsAVeryBigCommand: "noooo",
 		hello: "Yoooooooooo",

--- a/src/@types/Commands.d.ts
+++ b/src/@types/Commands.d.ts
@@ -2,7 +2,7 @@ type IUserCommands = Record<
   string,
   | string
   | React.JSX.Element
-  | ((args?: any) => React.JSX.Element | string | void)
+  | ((args?: any) => React.JSX.Element | string | void | Promise<string | void>)
 >;
 
 export default IUserCommands;

--- a/src/@types/Exchange.d.ts
+++ b/src/@types/Exchange.d.ts
@@ -1,10 +1,12 @@
+export type ObjExchange = {
+  command: string;
+  output: string | React.JSX.Element;
+  prompt: string;
+  pwd: string;
+}
+
 type IExchange =
-	| {
-			command: string;
-			output: string | React.JSX.Element;
-			prompt: string;
-			pwd: string;
-	  }
+	| ObjExchange
 	| string
 	| React.JSX.Element;
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -55,6 +55,7 @@ const Terminal = (props: ITerminalProps) => {
 	// States
 	const [promptWidth, setPromptWidth] = useState<number>();
 	const [structure, setStructure] = useState(directoryStructure);
+	const [isCommandActive, setIsCommandActive] = useState<boolean>(false);
 
 	// Refs
 	const promptRef = useRef<HTMLSpanElement>(null);
@@ -62,6 +63,10 @@ const Terminal = (props: ITerminalProps) => {
 
 	// Theme
 	const [terminalTheme, setTerminalTheme] = useTheme(theme);
+
+	const toggleCommandState = (commandState: boolean) => {
+		setIsCommandActive(commandState);
+	};
 
 	// Effects
 	useEffect(() => {
@@ -104,12 +109,14 @@ const Terminal = (props: ITerminalProps) => {
 				<div className="main-terminal">
 					<ExchangeHistory terminalTheme={terminalTheme} />
 					<div className="input-prompt">
-						<Prompt
-							prompt={prompt}
-							ref={promptRef}
-							pwd={pwd}
-							terminalTheme={terminalTheme}
-						/>
+						{!isCommandActive && (
+							<Prompt
+								prompt={prompt}
+								ref={promptRef}
+								pwd={pwd}
+								terminalTheme={terminalTheme}
+							/>
+						)}
 						<InputField
 							predictionColor={terminalTheme.predictionColor}
 							commandPrediction={commandPrediction}
@@ -120,6 +127,7 @@ const Terminal = (props: ITerminalProps) => {
 							commands={commands!}
 							autoCompleteAnimation={autoCompleteAnimation}
 							setTerminalTheme={setTerminalTheme}
+							toggleCommandState={toggleCommandState}
 						/>
 					</div>
 					<div className="scroll-div" ref={scrollDivRef} />


### PR DESCRIPTION
This is an early preview of how async commands can work with the current `exchangeHistory` structure. 
Things that need to change/get added: 
* loading cli spinner (This is a problem because cli-like loaders are scarce to find for React)
* props for modifying loading spinner